### PR TITLE
Add the cargo-audit tool

### DIFF
--- a/src/03_libraries.md
+++ b/src/03_libraries.md
@@ -23,6 +23,14 @@ version.
 > ### Recommendation:
 > <mark>TODO</mark>: run cargo-outdated to check dependencies status
 
+## cargo-audit
+
+Cargo-audit tool allows one to easily check for security vulnerabilities
+reported to the RustSec Advisory Database.
+
+> ### Recommendation:
+> <mark>TODO</mark>: run cargo-audit to check for known vulnerabilities
+
 ## Unsafe code in libraries
 
 <mark>TODO</mark>: `unsafe` blocks are discussed in the following chapter.


### PR DESCRIPTION
Hello,

Checking for known vulnerabilities in a crate's dependencies seems like a good recommendation. Of course, [cargo-audit](https://github.com/RustSec/cargo-audit) isn't perfect and the [RustSec Advisory Database](https://github.com/RustSec/advisory-db/) may not report every vulnerability, but it is worth using it.