### PR TITLE
Mention cargo-geiger to check for unsafe blocks

### DIFF
--- a/src/03_libraries.md
+++ b/src/03_libraries.md
@@ -38,5 +38,5 @@ One needs to ensure that this kind of block is not misused in project
 dependencies.
 
 > ### Recommendation:
-> <mark>TODO</mark>: check that no `unsafe` blocks appear in the imported
-> dependencies (with a tool?).
+> <mark>TODO</mark>: run cargo-geiger to check that no `unsafe` blocks appear in
+> the imported dependencies (note that there are currently false negatives)


### PR DESCRIPTION
I’ve added [`cargo-geiger`](https://github.com/anderejd/cargo-geiger) as a tool to check for `unsafe` blocks in dependencies, with a caution on [false negatives](https://github.com/anderejd/cargo-geiger/tree/2bd1a49218e4fe1afa0149704823917d51635431#known-issues).