### PR TITLE
Add chapter focused on FFI

### DIFF
--- a/src/04_language.md
+++ b/src/04_language.md
@@ -214,20 +214,6 @@ crate can catch all cases. Drawback: all functions need to be marked as
 [rustig](https://github.com/Technolution/rustig) (doesn't build here)
 -->
 
-### FFI and panics
-
-When calling Rust code from another language (for ex. C), the Rust code must
-be careful to never panic.
-Unwinding from Rust code into foreign code results in undefined behavior.
-
-> ### Rule {{#check LANG-FFIPANIC | Handle correctly `panic!` in FFI}}:
-> Rust code called from FFI must either ensure the function cannot panic, or use
-> `catch_unwind` or the `std::panic` module to ensure the rust code will not
-> abort or return in an unstable state.
-
-Note that `catch_unwind` will only catch unwinding panics, not those that abort
-the process.
-
 ## Standard library traits
 
  - Drop <mark>TODO</mark>

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -115,8 +115,8 @@ The following types are considered C-compatible:
 
 - integral or floating point primitive types,
 - `repr(C)`-annotated `struct`,
-- `repr(C)` or `repr(Int)`-annotated `enum` with only fieldless variants (where
-  `Int` is an integral primitive type),
+- `repr(C)` or `repr(Int)`-annotated `enum` with at least one variant and only
+  fieldless variants (where `Int` is an integral primitive type),
 - pointers.
 
 The following types are not C-compatible:

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -204,6 +204,20 @@ C++) are not obvious, cf. [RFC 2195].
 Automated tools to generate bindings, such as [rust-bindgen] or
 [cbindgen], may be of help in making types consistent between C and Rust.
 
+> ### Recommendation {{#check FFI-AUTOMATE | Use automatic binding generator tools}}
+>
+> In a secure Rust development, automated generation tools should be use to
+> generate binding when possible and maintain them continually.
+
+<!-- -->
+
+> **Warning**
+>
+> For binding C/C++ to Rust, [rust-bindgen] is able to automatically generate
+> the low-level binding. A high-level safe binding is still highly recommended.
+> Also some options of rust-bindgen may result in dangerous translations, in
+> particular `rustified_enum`.
+
 [rust-bindgen]: https://crates.io/crates/rust-bindgen
 [cbindgen]: https://crates.io/crates/cbindgen
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -227,7 +227,7 @@ the C standard library.
 
 [libc]: https://crates.io/crates/libc
 
-### Non-robust types: references, pointers, enums
+### Non-robust types: references, function pointers, enums
 
 A *trap representation* of a particular type is a representation (pattern of
 bits) that respects the type's representation constraints (such as size and
@@ -246,7 +246,6 @@ the C-compatible types:
 
 - `bool` (1 byte, 256 representations, only 2 valid ones),
 - references,
-- pointers,
 - function pointers,
 - enums,
 - floats (even if almost every language have the same understanding of what is
@@ -283,7 +282,7 @@ strong guarantees. For instance, some C++ subset (without reinterpretation)
 allows developers to do lot of type checking. Because Rust natively separates
 the safe and unsafe segments, the recommendation is to always use Rust to check
 when possible. Concerning risks, the most dangerous types are references,
-pointers, function references, and enums, and are discussed below.
+function references, and enums, and are discussed below.
 
 > **Warning**
 >
@@ -300,7 +299,7 @@ pointers, function references, and enums, and are discussed below.
 
 Although they are allowed by the Rust compiler, the use of Rust references in
 FFI may break Rust's memory safety. Because their “unsafety” is more explicit,
-pointers are recommended.
+pointers are preferred over Rust references when binding to another language.
 
 On the one hand, reference types are very non-robust: they allow only pointers
 to valid memory objects. Any deviation leads to undefined behavior.

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -67,7 +67,9 @@ fn main() {
 }
 ```
 
-## Data layout
+## Types
+
+### Data layout
 
 Rust provides no short or long term guarantees with respect to how the data is
 laid out in the memory. The only way to make data compatible with a foreign
@@ -143,7 +145,7 @@ References:
 [Rust Reference: Type Layout]: https://doc.rust-lang.org/reference/type-layout.html
 [Rust Book: Unsafe Rust]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
 
-## Pointers and references
+### Pointers and references
 
 Although they are allowed by the Rust compiler, the use of Rust references in
 FFI should be avoided. It is particularly true when binding to and from C,
@@ -182,7 +184,7 @@ is only manipulated from the Rust side of an FFI boundary.
 > side. The C `NULL` is understood as `None` in Rust while a non-null
 > pointer is encapsulated in `Some`.
 
-## Type consistency
+### Type consistency
 
 > ### Rule {{#check FFI-TCONS | Use consistent types at FFI boundaries}}
 >
@@ -200,6 +202,42 @@ Automated tools to generate bindings, such as [rust-bindgen] or
 
 [rust-bindgen]: https://crates.io/crates/rust-bindgen
 [cbindgen]: https://crates.io/crates/cbindgen
+
+### Platform-dependent types
+
+When interfacing with a foreign language, like C or C++, it is often required
+to use platform-dependent types such as C's `int`, `long`, etc.
+
+In addition to `c_void` in `std::ffi` (or `core::ffi`) for `void`, the standard
+library offers portable type aliases in `std:os::raw` (ore `core::os::raw`):
+
+- `c_char` for `char` (either `i8` or `u8`),
+- `c_schar` for `signed char` (always `i8`),
+- `c_uchar` for `unsigned char` (always `u8`),
+- `c_short` for `short`,
+- `c_ushort` for `unsigned short`,
+- `c_int` for `int`,
+- `c_uint` for `unsigned int`,
+- `c_long` for `long`,
+- `c_ulong` for `unsigned long`,
+- `c_longlong` for `long long`,
+- `c_ulonglong` for `unsigned long long`,
+- `c_float` for `float` (always `f32`),
+- `c_double` for `double` (always `f64`).
+
+The [libc] crate offers more C compatible types that cover almost exhaustively
+the C standard library.
+
+> Rule {{#check FFI-PFTYPE | Use portable aliases `c_*` when binding to platform-dependent types}}
+>
+> In a secure Rust development, when interfacing with foreign code that
+> uses platform-dependent types, such as C's `int` and `long`, Rust code must
+> use portable type aliases, such as provided by the standard library or the
+> [libc] crate, rather than platform-specific types, except if
+> the binding is automatically generated for each platform (for instance,
+> with a [cbindgen] step in the build process).
+
+[libc]: https://crates.io/crates/libc
 
 ## Panics with foreign code
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -209,7 +209,7 @@ When interfacing with a foreign language, like C or C++, it is often required
 to use platform-dependent types such as C's `int`, `long`, etc.
 
 In addition to `c_void` in `std::ffi` (or `core::ffi`) for `void`, the standard
-library offers portable type aliases in `std:os::raw` (ore `core::os::raw`):
+library offers portable type aliases in `std:os::raw` (or `core::os::raw`):
 
 - `c_char` for `char` (either `i8` or `u8`),
 - `c_schar` for `signed char` (always `i8`),

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -175,7 +175,8 @@ Automated tools to generate bindings, such as [rust-bindgen] or
 > **Warning**
 >
 > For binding C/C++ to Rust, [rust-bindgen] is able to automatically generate
-> the low-level binding. A high-level safe binding is still highly recommended.
+> the low-level binding. A high-level safe binding is highly recommended (see
+> Recommendation [FFI-SAFEWRAPPING](#FFI-SAFEWRAPPING)).
 > Also some options of rust-bindgen may result in dangerous translations, in
 > particular `rustified_enum`.
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -304,7 +304,7 @@ to valid memory objects. Any deviation leads to undefined behavior.
 > (see Note below).
 
 When binding to and from C, the problem is particularly severe because C has
-no references (in the sense of valid pointers) and the compiler do not offer
+no references (in the sense of valid pointers) and the compiler does not offer
 any safety guarantee.
 
 When binding with C++, Rust references may be bound to C++ references in

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -183,6 +183,10 @@ is only manipulated from the Rust side of an FFI boundary.
 > ### Rule {{#check FFI-TCONS | Use consistent types at FFI boundaries}}
 >
 > Types must be consistent on each side of the FFI boundary.
+>
+> Although some details may be hidden on one side with respect to the other
+> (typically to make a type opaque), types on both sides must have the same size
+> and the same alignment requirement.
 
 Concerning enums with fields in particular, the corresponding types in C (or
 C++) are not obvious, cf. [RFC 2195].

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -24,9 +24,10 @@ Conversely, one can call C functions from Rust if they are declared in an
 `extern` block:
 
 ```rust
+use std::os::raw::c_int;
 // import an external function from libc
 extern "C" {
-    fn abs(args: i32) -> i32;
+    fn abs(args: c_int) -> c_int;
 }
 
 fn main() {

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -162,7 +162,8 @@ because C has no references (in the sense of valid pointers):
 
 In case of binding to or from C++, it is possible to use Rust references on one
 side, and C++ references on the other. However, the C++ code should be checked
-against pointer/reference confusion.
+against pointer/reference confusion. Other reasonable exceptions include C
+variants allowing for non-null type checking, e.g. Microsoft SAL annotated code.
 
 > ### Rule {{#check FFI-CKPTR | Check foreign pointers}}
 >

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -230,19 +230,30 @@ the C standard library.
 
 A *trap representation* of a particular type is a representation (pattern of
 bits) that respects the type's representation constraints (such as size and
-alignment) but does not represent a valid value of this type.
+alignment) but does not represent a valid value of this type and lead to
+undefined behavior.
 
-A lot of Rust types have trap representations:
+In simple term, if a Rust variable is set to such an invalid value,
+anything can happen from simple program crash to arbitrary code execution. When
+writing safe Rust, this cannot happen (except through a bug in the Rust
+compiler). However, when writing unsafe Rust and in particular in FFI, it is
+really easy.
+
+In the following, **non-robust types** are types that have such trap
+representations (at least one). A lot of Rust types are non-robust, even among
+the C-compatible types:
 
 - `bool` (1 byte, 256 representations, only 2 valid ones),
 - references,
 - pointers,
 - function pointers,
 - enums,
-- compound types that contain a non-robust type.
+- floats (even if almost every language have the same understanding of what is
+  a valid float),
+- compound types that contain a field of a non-robust type.
 
-In the following we called such types, *non-robust types*. On the other hand,
-integer types (`u*`/`i*`) for instance are *robust types*.
+ On the other hand, integer types (`u*`/`i*`), packed compound types that
+ contain no non-robust fields, for instance are *robust types*.
 
 Non-robust types are a difficulty when interfacing two languages. It revolves
 into deciding **which language of the two is responsible in asserting the

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -145,7 +145,7 @@ References:
 
 ## Pointers and references
 
-Although there are allowed by the Rust compiler, the use of Rust references in
+Although they are allowed by the Rust compiler, the use of Rust references in
 FFI should be avoided. It is particularly true when binding to and from C,
 because C has no references (in the sense of valid pointers):
 
@@ -157,7 +157,8 @@ because C has no references (in the sense of valid pointers):
 > - the prototype of an imported or exported function,
 > - the type of an imported or exported global variables,
 >
-> directly or indirectly (in a non-opaque subtype).
+> directly or indirectly (in a non-opaque subtype), except for `Option`-wrapped
+> references (see Note below).
 
 In case of binding to or from C++, it is possible to use Rust references on one
 side, and C++ references on the other. However, the C++ code should be checked
@@ -174,10 +175,11 @@ is only manipulated from the Rust side of an FFI boundary.
 
 > ### Note
 >
-> It is possible to use the type `Option<&T>` (resp. `Option<&mut T>`) instead
-> of pointers with nullity checks. However, because it is less explicit and
-> relies on Rust “nullable pointer optimization”, it is not advisable at this
-> point.
+> `Option<&T>` and `Option<&mut T>` for any `T: Sized` are allowable in FFI
+> instead of pointers with explicit nullity checks. Due to the Rust guaranteed
+> “nullable pointer optimization”, a nullable pointer is acceptable on the C
+> side. The C `NULL` is understood as `None` in Rust while a non-null
+> pointer is encapsulated in `Some`.
 
 ## Type consistency
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -375,11 +375,21 @@ unsafe extern fn add_in_place(a: *mut u32, b: u32) {
 
 Note that the methods `as_ref` and `as_mut` (for mutable pointers) allows easy
 access to a reference while ensuring a null check in a very *Rusty* way.
-On the other side, one could use this prototype in C:
+On the other side in C, it can be used as follows:
 
 ```c
+#include <stdint.h>
+#include <inttypes.h>
+
 //! Add in place
 void add_in_place(uint32_t *a, uint32_t b);
+
+int main() {
+    uint32_t x = 25;
+    add_in_place(x, 17);
+    printf("%" PRIu32 " == 42", x);
+    return 0;
+}
 ```
 
 > ### Note

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -167,8 +167,8 @@ Automated tools to generate bindings, such as [rust-bindgen] or
 
 > ### Recommendation {{#check FFI-AUTOMATE | Use automatic binding generator tools}}
 >
-> In a secure Rust development, automated generation tools should be use to
-> generate binding when possible and maintain them continually.
+> In a secure Rust development, automated generation tools should be used to
+> generate bindings when possible and to maintain them continually.
 
 <!-- -->
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -1,7 +1,10 @@
 # Interfacing (FFI)
 
-Rust approach to interfacing with other programs relies on a strong
-compatibility with C. However, this boundary is by its very nature `unsafe`.
+Rust approach to interfacing with other languages relies on a strong
+compatibility with C. However, this boundary is by its very nature **unsafe**
+(see [Rust Book: Unsafe Rust]).
+
+[Rust Book: Unsafe Rust]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
 
 Functions that are marked `extern` are made compatible with C code at the
 compilation. They may be called from C code with any parameter.
@@ -78,7 +81,8 @@ binding is essential to maintain the memory safety.
 Rust provides no short or long term guarantees with respect to how the data is
 laid out in the memory. The only way to make data compatible with a foreign
 language is through explicit use of a C-compatible data layout with the `repr`
-attribute. For instance, the following Rust types:
+attribute (see [Rust Reference: Type Layout]). For instance, the following Rust
+types:
 
 ```rust
 #[repr(C)]
@@ -116,6 +120,9 @@ struct PackedData {
 > In a secure Rust development, only C-compatible types must be used as
 > parameter or return type of imported or exported functions and as types of
 > imported or exported global variables.
+>
+> The lone exception is types that are considered **opaque** on the foreign
+> side.
 
 The following types are considered C-compatible:
 
@@ -137,17 +144,10 @@ Some types are compatibles with some caveats:
 - Zero-sized types, which is really zero sized (which is let unspecified in C
   and contradicts the C++ specification),
 - `repr(C)`, `repr(C, Int)`, or `repr(Int)`-annotated enum with fields
-  ([RFC 2195]).
+  (see [RFC 2195]).
 
-References:
-
-- [RFC 2195 (Really tagged unions)][RFC 2195]
-- [Rust Reference: Type Layout]
-- [Rust Book: Unsafe Rust]
-
-[RFC 2195]: https://github.com/rust-lang/rfcs/blob/master/text/2195-really-tagged-unions.md
+[RFC 2195]: https://rust-lang.github.io/rfcs/2195-really-tagged-unions.html
 [Rust Reference: Type Layout]: https://doc.rust-lang.org/reference/type-layout.html
-[Rust Book: Unsafe Rust]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
 
 ### Pointers and references
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -481,7 +481,7 @@ environment.
 
 Concerning fieldless enums, crates like [`num_derive`] or [`num_enum`] allows
 developer to easily provide safe conversion from integer to enumeration and may
-be use to safely convert a integer (provided from a C `enum`) into a Rust enum.
+be use to safely convert an integer (provided from a C `enum`) into a Rust enum.
 
 [num_derive]: https://crates.io/crates/num_derive
 [num_enum]: https://crates.io/crates/num_enum

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -361,7 +361,7 @@ an `unsafe` block or function.
 The following code a simple example of foreign pointer use in an exported Rust
 function:
 
-```rust
+```rust,noplaypen
 /// Add in place
 #[no_mangle]
 unsafe extern fn add_in_place(a: *mut u32, b: u32) {
@@ -408,9 +408,9 @@ possibilities:
 
 - use `Option`-wrapped function pointer and check against `null`:
 
-  ```rust
+  ```rust,noplaypen
   #[no_mangle]
-  unsafe extern "C" fn repeat(start: u32, n: u32, f: Option<unsafe extern "C" fn(u32) -> u32>) -> u32 {
+  pub unsafe extern "C" fn repeat(start: u32, n: u32, f: Option<unsafe extern "C" fn(u32) -> u32>) -> u32 {
       if let Some(f) = f {
           let mut value = start;
           for _ in 0..n {
@@ -488,7 +488,7 @@ When doing multilingual development, it is something very common.
 
 Currently the recommended way to make a foreign opaque type is like so:
 
-```rust ignore
+```rust,unsafe,noplaypen
 #[repr(C)]
 pub struct Foo {_private: [u8; 0]}
 extern "C" {
@@ -520,9 +520,9 @@ struct Opaque {
 #[no_mangle]
 pub unsafe extern "C" fn new_opaque() -> *mut Opaque {
     catch_unwind(|| // Catch panics, see below
-    Box::into_raw(Box::new(Opaque {
-        // (...) actual construction
-    }))
+        Box::into_raw(Box::new(Opaque {
+            // (...) actual construction
+        }))
     ).unwrap_or(std::ptr::null_mut())
 }
 
@@ -530,8 +530,8 @@ pub unsafe extern "C" fn new_opaque() -> *mut Opaque {
 pub unsafe extern "C" fn destroy_opaque(o: *mut Opaque) {
     catch_unwind(||
         if !o.is_null() {
-    drop(Box::from_raw(o))
-}
+            drop(Box::from_raw(o))
+        }
     ); // Only needed if Opaque or one of its subfield is Drop
 }
 ```
@@ -552,9 +552,9 @@ Unwinding from Rust code into foreign code results is **undefined behavior**.
 Note that `catch_unwind` will only catch unwinding panics, not those that abort
 the process.
 
-```rust ignore
+```rust,unsafe,noplaypen,ignore
 use std::panic::catch_unwind;
-use rand;
+# use rand;
 
 fn may_panic() {
     if rand::random() {
@@ -619,7 +619,7 @@ the Rust C-compatible API of a Rust library.
 
 `src/lib.rs`:
 
-```rust
+```rust,noplaypen
 /// Opaque counter
 pub struct Counter(u32);
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -243,7 +243,7 @@ Another approach is to simply ensure that there is no use of `panic!` with the
 [`panic-never`] crate. Like [`no-panic`], [`panic-never`] relies on a linking
 trick: the linker fails if a non-trivially-dead branch leads to `panic!`.
 
-[`panic-never`]: https://crate.io/crates/panic-never
+[`panic-never`]: https://crates.io/crates/panic-never
 [`no-panic`]: https://github.com/dtolnay/no-panic
 
 ## Binding a foreign library in Rust

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -1,0 +1,391 @@
+# Interfacing (FFI)
+
+Rust approach to interfacing with other programs relies on a strong
+compatibility with C. However, this boundary is by its very nature `unsafe`.
+
+Functions that are marked `extern` are made compatible with C code at the
+compilation. They may be called from C code with any parameter.
+The exact syntax is `extern "<ABI>"` where ABI is a calling convention and
+depends on the target platform. The default one is `C` which corresponds to
+a standard C calling convention on the target platform.
+
+```rust
+// export a C-compatible function
+#[no_mangle]
+pub extern "C" fn mylib_f(param: u32) -> i32 {
+    if param == 0xCAFEBABE { 0 } else { -1 }
+}
+```
+
+For the function `mylib_f` to be accessible with the same name, the function
+must also be annotated with the `#[no_mangle]` attribute.
+
+Conversely, one can call C functions from Rust if they are declared in an
+`extern` block:
+
+```rust
+// import an external function from libc
+extern "C" {
+    fn abs(args: i32) -> i32;
+}
+
+fn main() {
+    let x = -1;
+    println!("{} {}\n", x, unsafe { abs(x) });
+}
+```
+
+> **Note**
+>
+> Any foreign function imported in Rust through an `extern` block is
+> **automatically `unsafe`**. That is why, any call to a foreign function
+> must be done from an `unsafe` context.
+
+`extern` blocks may also contain foreign global variable declarations prefixed
+with the `static` keyword:
+
+```rust
+//! A direct way to access environment variables (on Unix).
+//! Should not be used! Not thread safe, have a look at `std::env`!
+
+extern {
+    // Libc global variable
+    #[link_name = "environ"]
+    static libc_environ: *const *const std::os::raw::c_char;
+}
+
+fn main() {
+    let mut next = unsafe { libc_environ };
+    while !next.is_null() && !unsafe { *next }.is_null() {
+        let env = unsafe { std::ffi::CStr::from_ptr(*next) }
+            .to_str()
+            .unwrap_or("<invalid>");
+        println!("{}", env);
+        next = unsafe { next.offset(1) };
+    }
+}
+```
+
+## Data layout
+
+Rust provides no short or long term guarantees with respect to how the data is
+laid out in the memory. The only way to make data compatible with a foreign
+language is through explicit use of a C-compatible data layout with the `repr`
+attribute. For instance, the following Rust types:
+
+```rust
+#[repr(C)]
+struct Data {
+    a: u32,
+    b: u16,
+    c: u64,
+}
+#[repr(C, packed)]
+struct PackedData {
+    a: u32,
+    b: u16,
+    c: u64,
+}
+```
+
+are compatible with the following C types:
+
+```c
+struct Data {
+    uint32_t a;
+    uint16_t b;
+    uint64_t c;
+};
+__attribute__((packed))
+struct PackedData {
+    uint32_t a;
+    uint16_t b;
+    uint64_t c;
+}
+```
+
+> ### Rule {{#check FFI-CTYPE | Use only C-compatible types in FFI}}
+>
+> In a secure Rust development, only C-compatible types must be used as
+> parameter or return type of imported or exported functions and as types of
+> imported or exported global variables.
+
+The following types are considered C-compatible:
+
+- integral or floating point primitive types,
+- `repr(C)`-annotated `struct`,
+- `repr(C)` or `repr(Int)`-annotated `enum` with only fieldless variants (where
+  `Int` is an integral primitive type),
+- pointers.
+
+The following types are not C-compatible:
+
+- Dynamically sized types,
+- Trait objects,
+- Enums with fields,
+- Tuples (but `repr(C)` tuple structures are OK).
+
+Some types are compatibles with some caveats:
+
+- Zero-sized types, which is really zero sized (which is let unspecified in C
+  and contradicts the C++ specification),
+- `repr(C)`, `repr(C, Int)`, or `repr(Int)`-annotated enum with fields
+  ([RFC 2195]).
+
+References:
+
+- [RFC 2195 (Really tagged unions)][RFC 2195]
+- [Rust Reference: Type Layout]
+- [Rust Book: Unsafe Rust]
+
+[RFC 2195]: https://github.com/rust-lang/rfcs/blob/master/text/2195-really-tagged-unions.md
+[Rust Reference: Type Layout]: https://doc.rust-lang.org/reference/type-layout.html
+[Rust Book: Unsafe Rust]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
+
+## Pointers and references
+
+Although there are allowed by the Rust compiler, the use of Rust references in
+FFI should be avoided. It is particularly true when binding to and from C,
+because C has no references (in the sense of valid pointers):
+
+> ### Rule {{#check FFI-NOREF | Do not use unchecked references in FFI}}
+>
+> In a secure Rust development, there must be no Rust reference types when
+> interfacing with C, in particular, in:
+>
+> - the prototype of an imported or exported function,
+> - the type of an imported or exported global variables,
+>
+> directly or indirectly (in a non-opaque subtype).
+
+In case of binding to or from C++, it is possible to use Rust references on one
+side, and C++ references on the other. However, the C++ code should be checked
+against pointer/reference confusion.
+
+> ### Rule {{#check FFI-CKPTR | Check foreign pointers}}
+>
+> In a secure Rust development, any Rust code that dereferences a foreign
+> pointer must check their validity beforehand.
+> In particular, pointers must be checked to be non-null before any use.
+
+Stronger approaches such as _tagged pointers_ are possible if the pointed value
+is only manipulated from the Rust side of an FFI boundary.
+
+> ### Note
+>
+> It is possible to use the type `Option<&T>` (resp. `Option<&mut T>`) instead
+> of pointers with nullity checks. However, because it is less explicit and
+> relies on Rust “nullable pointer optimization”, it is not advisable at this
+> point.
+
+## Type consistency
+
+> ### Rule {{#check FFI-TCONS | Use consistent types at FFI boundaries}}
+>
+> Types must be consistent on each side of the FFI boundary.
+
+Concerning enums with fields in particular, the corresponding types in C (or
+C++) are not obvious, cf. [RFC 2195].
+
+Automated tools to generate bindings, such as [rust-bindgen] or
+[cbindgen], may be of help in making types consistent between C and Rust.
+
+[rust-bindgen]: https://github.com/rust-lang/rust-bindgen
+[cbindgen]: https://github.com/eqrion/cbindgen
+
+## Panics with foreign code
+
+When calling Rust code from another language (e.g. C), the Rust code must
+be careful to never panic.
+Unwinding from Rust code into foreign code results is **undefined behavior**.
+
+> ### Rule {{#check FFI-NOPANIC | Handle `panic!` correctly in FFI}}
+>
+> Rust code called from FFI must either ensure the function cannot panic, or use
+> a panic handling mechanism (such as `std::panic::catch_unwind`,
+> `std::panic::set_hook`, `#[panic_handler]`) to ensure the rust code will not
+> abort or return in an unstable state.
+
+Note that `catch_unwind` will only catch unwinding panics, not those that abort
+the process.
+
+```rust ignore
+use std::panic::catch_unwind;
+use rand;
+
+pub fn may_panic() {
+    if rand::random() {
+        panic!("panic happens");
+    }
+}
+
+#[no_mangle]
+pub extern fn no_panic() -> i32 {
+    let result = catch_unwind(||may_panic());
+    match result {
+        Ok(_) => 0,
+        Err(_) => -1,
+    }
+}
+```
+
+### `no_std`
+
+In the case of `#![no_std]` program, a panic handler (`#[panic_handler]`) must
+be defined to ensure security. The panic handler should be written with great
+care in order to ensure both the safety and security of the program.
+
+Another approach is to simply ensure that there is no use of `panic!` with the
+[`panic-never`] crate. Like [`no-panic`], [`panic-never`] relies on a linking
+trick: the linker fails if a non-trivially-dead branch leads to `panic!`.
+
+[`panic-never`]: https://crate.io/crates/panic-never
+[`no-panic`]: https://github.com/dtolnay/no-panic
+
+## Binding a foreign library in Rust
+
+> ### Recommendation {{#check FFI-SAFEWRAPPING | Provide safe wrapping to foreign library}}
+>
+> Interfacing a library written in another language in Rust should be done in
+> two parts:
+>
+> - a low-level, possibly *hidden*, module that closely translates the original
+>   C API into `extern` blocks,
+> - a safe wrapping module that ensures memory safety and security invariants at
+>   the Rust level.
+>
+> If the low-level API is exposed to the world, it should be done in a dedicated
+> crate with a name of the form `*-sys`.
+
+The crate [rust-bindgen] may be used to automatically generate the low-level
+part of the binding from C header files.
+
+<mark>TODO</mark> example
+
+## Binding a Rust library in another language
+
+> ### Recommendation {{#check FFI-CAPI | Expose dedicated C-compatible API only}}
+>
+> In a secure Rust development, exposing a Rust library to a foreign language
+> should only be done through a **dedicated C-compatible API**.
+
+The crate [cbindgen] may be used to automatically generate C or C++ bindings to
+the Rust C-compatible API of a Rust library.
+
+### Minimal example of a C-exported Rust library
+
+`src/lib.rs`:
+
+```rust
+/// Opaque counter
+pub struct Counter(u32);
+
+impl Counter {
+    /// Create a counter (initially at 0)
+    fn new() -> Self {
+        Self(0)
+    }
+    /// Get the current value of the counter
+    fn get(&self) -> u32 {
+        self.0
+    }
+    /// Increment the value of the counter if there's no overflow
+    fn incr(&mut self) -> bool {
+        if let Some(n) = self.0.checked_add(1) {
+            self.0 = n;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+// C-compatible API
+
+#[no_mangle]
+pub extern fn counter_create() -> *mut Counter {
+    Box::into_raw(Box::new(Counter::new()))
+}
+
+#[no_mangle]
+pub extern fn counter_incr(counter: *mut Counter) -> std::os::raw::c_int {
+    if let Some(counter) = unsafe { counter.as_mut() } {
+        if counter.incr() {
+            0
+        } else {
+            -1
+        }
+    } else {
+        -2
+    }
+}
+
+#[no_mangle]
+pub extern fn counter_get(counter: *const Counter) -> u32 {
+    if let Some(counter) = unsafe { counter.as_ref() } {
+        return counter.get();
+    }
+    return 0;
+}
+
+#[no_mangle]
+pub extern fn counter_destroy(counter: *mut Counter) -> std::os::raw::c_int {
+    if !counter.is_null() {
+        let _ = unsafe { Box::from_raw(counter) }; // get box and drop
+        return 0;
+    }
+    return -1;
+}
+```
+
+Using [cbindgen] (`[cbindgen] -l c > counter.h`), one can generate a consistent
+C header, `counter.h`:
+
+```c
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct Counter Counter;
+
+Counter *counter_create(void);
+
+int counter_destroy(Counter *counter);
+
+uint32_t counter_get(const Counter *counter);
+
+int counter_incr(Counter *counter);
+```
+
+`counter_main.c`:
+
+```c
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "counter.h"
+
+int main(int argc, const char** argv) {
+    Counter* c = counter_create();
+
+    if (argc < 2) {
+        return -1;
+    }
+    size_t n = (size_t)strtoull(argv[1], NULL, 10);
+
+    for (size_t i=0; i < n; i++) {
+        if (counter_incr(c) != 0) {
+            printf("overflow\n");
+            return -1;
+        }
+    }
+
+    printf("%" PRIu32 "\n", counter_get(c));
+    counter_destroy(c);
+
+    return 0;
+}
+```

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -393,7 +393,7 @@ int main() {
 }
 ```
 
-> ### Note
+> **Note**
 >
 > `Option<&T>` and `Option<&mut T>` for any `T: Sized` are allowable in FFI
 > instead of pointers with explicit nullity checks. Due to the Rust guaranteed

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -195,8 +195,8 @@ C++) are not obvious, cf. [RFC 2195].
 Automated tools to generate bindings, such as [rust-bindgen] or
 [cbindgen], may be of help in making types consistent between C and Rust.
 
-[rust-bindgen]: https://github.com/rust-lang/rust-bindgen
-[cbindgen]: https://github.com/eqrion/cbindgen
+[rust-bindgen]: https://crates.io/crates/rust-bindgen
+[cbindgen]: https://crates.io/crates/cbindgen
 
 ## Panics with foreign code
 
@@ -245,7 +245,7 @@ Another approach is to simply ensure that there is no use of `panic!` with the
 trick: the linker fails if a non-trivially-dead branch leads to `panic!`.
 
 [`panic-never`]: https://crates.io/crates/panic-never
-[`no-panic`]: https://github.com/dtolnay/no-panic
+[`no-panic`]: https://crates.io/crates/no-panic
 
 ## Binding a foreign library in Rust
 

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -253,8 +253,8 @@ the C-compatible types:
   a valid float),
 - compound types that contain a field of a non-robust type.
 
- On the other hand, integer types (`u*`/`i*`), packed compound types that
- contain no non-robust fields, for instance are *robust types*.
+On the other hand, integer types (`u*`/`i*`), packed compound types that contain
+no non-robust fields, for instance are *robust types*.
 
 Non-robust types are a difficulty when interfacing two languages. It revolves
 into deciding **which language of the two is responsible in asserting the

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -364,7 +364,7 @@ function:
 ```rust,noplaypen
 /// Add in place
 #[no_mangle]
-unsafe extern fn add_in_place(a: *mut u32, b: u32) {
+pub unsafe extern fn add_in_place(a: *mut u32, b: u32) {
     // checks for nullity of `a`
     // and takes a mutable reference on it if it's non-null
     if let Some(a) = a.as_mut() {
@@ -573,8 +573,8 @@ fn may_panic() {
 }
 
 #[no_mangle]
-unsafe extern "C" fn no_panic() -> i32 {
-    let result = catch_unwind(||may_panic());
+pub unsafe extern "C" fn no_panic() -> i32 {
+    let result = catch_unwind(may_panic);
     match result {
         Ok(_) => 0,
         Err(_) => -1,
@@ -656,12 +656,12 @@ impl Counter {
 // C-compatible API
 
 #[no_mangle]
-unsafe extern "C" fn counter_create() -> *mut Counter {
+pub unsafe extern "C" fn counter_create() -> *mut Counter {
     Box::into_raw(Box::new(Counter::new()))
 }
 
 #[no_mangle]
-unsafe extern "C" fn counter_incr(counter: *mut Counter) -> std::os::raw::c_int {
+pub unsafe extern "C" fn counter_incr(counter: *mut Counter) -> std::os::raw::c_int {
     if let Some(counter) = counter.as_mut() {
         if counter.incr() {
             0
@@ -674,7 +674,7 @@ unsafe extern "C" fn counter_incr(counter: *mut Counter) -> std::os::raw::c_int 
 }
 
 #[no_mangle]
-unsafe extern "C" fn counter_get(counter: *const Counter) -> u32 {
+pub unsafe extern "C" fn counter_get(counter: *const Counter) -> u32 {
     if let Some(counter) = counter.as_ref() {
         return counter.get();
     }
@@ -682,7 +682,7 @@ unsafe extern "C" fn counter_get(counter: *const Counter) -> u32 {
 }
 
 #[no_mangle]
-unsafe extern fn counter_destroy(counter: *mut Counter) -> std::os::raw::c_int {
+pub unsafe extern fn counter_destroy(counter: *mut Counter) -> std::os::raw::c_int {
     if !counter.is_null() {
         let _ = Box::from_raw(counter); // get box and drop
         return 0;

--- a/src/06_ffi.md
+++ b/src/06_ffi.md
@@ -67,7 +67,11 @@ fn main() {
 }
 ```
 
-## Types
+## Typing
+
+Typing is the way Rust ensures memory safety. When interfacing with other
+languages, which may not offer the same guarantee, the choice of types in the
+binding is essential to maintain the memory safety.
 
 ### Data layout
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -5,5 +5,6 @@
 - [Libraries](03_libraries.md)
 - [The language](04_language.md)
 - [Test and fuzzing](05_test_fuzz.md)
+- [Interfacing (FFI)](06_ffi.md)
 
 [Licence](LICENCE.md)


### PR DESCRIPTION
- [x] Remove FFI from Language chapter
- [x] Data layout requirements
- [x] Pointer vs reference and mandatory pointer null check
- [x] Type consistency
- [x] More hands on recs when doing FFI manually such as using libc crate's types
- [x] "extremely advisable property: no drop glue for the involved types, i.e., avoid, or at least justify, the usage of non-Copy types" @danielhenrymantilla 
- [x] Panics and FFI
- [x] Panics and no_std
- [x] C->Rust
   - [x] Two part binding recommendation
   - [ ] Example
- [x] Rust->C
   - [x] Dedicated C API recommendation
   - [x] Example