### PR TITLE
Update error crates rec

### DIFF
--- a/src/en/04_language.md
+++ b/src/en/04_language.md
@@ -121,18 +121,30 @@ The `Result` type is the preferred way of handling functions that can fail.
 A `Result` object must be tested, and never ignored.
 
 > ### Recommendation {{#check LANG-ERRWRAP | Implement custom `Error` type, wrapping all possible errors}}
-> A crate can implement its own Error type, wrapping all possible errors.
+>
+> A crate can implement its own `Error` type, wrapping all possible errors.
 > It must be careful to make this type exception-safe (RFC 1236), and implement
 > `Error + Send + Sync + 'static` as well as `Display`.
 
 > ### Recommendation {{#check LANG-ERRDO | Use the `?` operator and do not use the `try!` macro}}
+>
 > The `?` operator should be used to improve readability of code.
 > The `try!` macro should not be used.
 
-The [error-chain] and [failure] crates can be used to wrap errors.
+Third-party crates may be used to facilitate error handling. Most of them
+(notably [failure], [snafu], [thiserror]) address the creation of new custom
+error types that implement the necessary traits and allow wrapping other
+errors.
 
-[error-chain]: https://crates.io/crates/error-chain
+Another approach (notably proposed in the [anyhow] crate) consists in an automatic
+wrapping of errors into a single universal error type. Such wrappers should not
+be used in libraries and complex systems because they do not allow developers to
+provide context to the wrapped error.
+
 [failure]: https://crates.io/crates/failure
+[snafu]: https://crates.io/crates/snafu
+[thiserror]: https://crates.io/crates/thiserror
+[anyhow]: https://crates.io/crates/anyhow
 
 ### Panics
 

--- a/src/fr/04_language.md
+++ b/src/fr/04_language.md
@@ -143,11 +143,21 @@ testé et jamais ignoré.
 > L'opérateur `?` doit être utilisé pour améliorer la lisibilité du code.
 > La macro `try!` ne doit pas être utilisée.
 
-Les *crates* [error-chain] et [failure] peuvent être utilisées pour contenir les
-types d'erreurs.
+Des *crates* tiers, peuvent être utilisés pour faciliter la gestion d'erreurs.
+La plupart ([failure], [snafu], [thiserror]) adressent la création de types
+d'erreurs personnalisées qui implémentent les traits nécessaires et permettent
+l'encapsulation d'autres erreurs.
 
-[error-chain]: https://crates.io/crates/error-chain
+Une autre approche (notamment proposée dans [anyhow]) consiste à envelopper
+automatiquement les erreurs dans un seul type d'erreurs universel. Une telle
+approche ne devrait pas être utilisée dans des bibliothèques ou des systèmes
+complexes parce qu'elle ne permet pas de fournir de contexte aux erreurs
+contenues, contrairement à la première approche.
+
 [failure]: https://crates.io/crates/failure
+[snafu]: https://crates.io/crates/snafu
+[thiserror]: https://crates.io/crates/thiserror
+[anyhow]: https://crates.io/crates/anyhow
 
 ### *Panics*
 


### PR DESCRIPTION
Remove `error-chain` which is not maintained any more.
Add a short selection of current crates.

Informal rec about not wrapping without semantics in libraries or complex systems.
Maybe it should be something more formal?