### PR TITLE
Fix memory leak in last FFI code snippet

### DIFF
--- a/src/en/07_ffi.md
+++ b/src/en/07_ffi.md
@@ -956,16 +956,16 @@ int counter_incr(Counter *counter);
 #include "counter.h"
 
 int main(int argc, const char** argv) {
-    Counter* c = counter_create();
-
     if (argc < 2) {
         return -1;
     }
     size_t n = (size_t)strtoull(argv[1], NULL, 10);
 
+    Counter* c = counter_create();
     for (size_t i=0; i < n; i++) {
         if (counter_incr(c) != 0) {
             printf("overflow\n");
+            counter_destroy(c);
             return -1;
         }
     }

--- a/src/fr/07_ffi.md
+++ b/src/fr/07_ffi.md
@@ -1017,16 +1017,16 @@ int counter_incr(Counter *counter);
 #include "counter.h"
 
 int main(int argc, const char** argv) {
-    Counter* c = counter_create();
-
     if (argc < 2) {
         return -1;
     }
     size_t n = (size_t)strtoull(argv[1], NULL, 10);
 
+    Counter* c = counter_create();
     for (size_t i=0; i < n; i++) {
         if (counter_incr(c) != 0) {
             printf("overflow\n");
+            counter_destroy(c);
             return -1;
         }
     }


### PR DESCRIPTION
If we return from the main without first destroying the counter we will leak memory.