### PR TITLE
Add some missing FFI safe types

### DIFF
--- a/src/en/07_ffi.md
+++ b/src/en/07_ffi.md
@@ -130,7 +130,14 @@ The following types are considered C-compatible:
 - `repr(C)`-annotated `struct`,
 - `repr(C)` or `repr(Int)`-annotated `enum` with at least one variant and only
   fieldless variants (where `Int` is an integral primitive type),
-- pointers.
+- pointers,
+- an `Option<T>` where `T` is either
+  - `core::ptr::NonNull<U>` and `U` is a `Sized` C-compatible type, then it is
+      compatible to a `*const T` and `*mut T` pointer;
+  - `core::num::NonZero*`, then is compatible to the corresponding integral
+      primitive type;
+- a `repr(transparent)`-annotated `struct` with only one field, where that
+  field has a C-compatible type.
 
 The following types are not C-compatible:
 


### PR DESCRIPTION
These additional types have representations that are defined to be the
same as some underlying FFI safe representation.