### PR TITLE
Rules shall enforce things

### DIFF
--- a/src/en/02_devenv.md
+++ b/src/en/02_devenv.md
@@ -199,7 +199,7 @@ For more information about the guidelines that `rustfmt` will check, have a look
 at the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md).
 
 > ### Rule {{#check DENV-FORMAT | Use Rust formatter (rustfmt)}}
-> The tool `rustfmt` can be used to ensure that the codebase respects style
+> The tool `rustfmt` must be used to ensure that the codebase respects style
 > guidelines (as described in `rustfmt.toml` file), with `--check` option and
 > manual review.
 

--- a/src/fr/02_devenv.md
+++ b/src/fr/02_devenv.md
@@ -228,7 +228,7 @@ Pour plus d'informations à propos des règles de convention de style que
 
 > ### Règle {{#check DENV-FORMAT | Utilisation d'un outil de formatage (rustfmt)}}
 >
-> L'outil de formatage `rustfmt` peut être utilisé pour assurer le respect de
+> L'outil de formatage `rustfmt` doit être utilisé pour assurer le respect de
 > règles de convention de style (comme décrites dans le fichier `rustfmt.toml`)
 > sur une base de code, avec l'option `--check` ainsi qu'une revue de code
 > manuelle.


### PR DESCRIPTION
Rule 5 is currently written as a suggestion:
> The tool `rustfmt` can be used to ensure...

 This is the only rule written this way, and it defeats its purpose.

This PR changes "can" to "must".

### Other approaches
There are other possibilities, for example:
- Removing this rule
- Adding a "Suggestion/Best practice" block for non-mandatory things