### PR TITLE
(fr) Add link to french-translated Rust book.

### DIFF
--- a/src/fr/07_ffi.md
+++ b/src/fr/07_ffi.md
@@ -2,8 +2,10 @@
 
 L'approche de Rust en ce qui concerne l'interfaçage avec des fonctions d'autres
 langages repose sur une compatibilité forte avec le C. Toutefois, cette
-frontière est par nature **non sûre** (voir [Rust Book: Unsafe Rust]).
+frontière est par nature **non sûre** (voir [Le livre Rust : Le Rust non
+sécurisé] ou [Rust Book: Unsafe Rust]).
 
+[Le livre Rust : Le Rust non sécurisé]: https://jimskapt.github.io/rust-book-fr/ch19-01-unsafe-rust.html
 [Rust Book: Unsafe Rust]: https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
 
 Les fonctions marquées comme externes (mot-clé `extern`) sont rendues


### PR DESCRIPTION
Hello, I've just discovered this book and I'm pretty exited to start reading it !

I'm the main contributor of [the french translation of `The Rust Programming Language`](https://github.com/Jimskapt/rust-book-fr) (linked as translation [in original book](https://doc.rust-lang.org/book/appendix-06-translation.html)) and I was thinking it would be relevant to link it in the (upcomming) french version of this guide, do you agree ?
