### PR TITLE
Fix ffi's "rust-bindgen" link

### DIFF
--- a/src/en/07_ffi.md
+++ b/src/en/07_ffi.md
@@ -180,7 +180,7 @@ Automated tools to generate bindings, such as [rust-bindgen] or
 > Also some options of rust-bindgen may result in dangerous translations, in
 > particular `rustified_enum`.
 
-[rust-bindgen]: https://crates.io/crates/rust-bindgen
+[rust-bindgen]: https://crates.io/crates/bindgen
 [cbindgen]: https://crates.io/crates/cbindgen
 
 ### Platform-dependent types

--- a/src/fr/07_ffi.md
+++ b/src/fr/07_ffi.md
@@ -185,7 +185,7 @@ types du côté C et ceux du côté Rust.
 > [FFI-SAFEWRAPPING](#FFI-SAFEWRAPPING)). Attention également à certaines
 > options dangereuses de `rust-bindgen`, en particulier `rustified_enum`.
 
-[rust-bindgen]: https://crates.io/crates/rust-bindgen
+[rust-bindgen]: https://crates.io/crates/bindgen
 [cbindgen]: https://crates.io/crates/cbindgen
 
 ### Types dépendants de la plateforme d'exécution


### PR DESCRIPTION
The rust-bindgen link is broken and points to a yanked, non-existent crate. 

The broken is due to changes made in [49822911e4f14b7cfb4df47b5c295bc35aec0790](https://github.com/ANSSI-FR/rust-guide/commit/49822911e4f14b7cfb4df47b5c295bc35aec0790#diff-cd01e52d548d81932fe4fcfe5eba53b64d70f9520f6e895550ef480e700a7639R198), which changes the github link to crates.io link but fails to locate the correct crate.