### PR TITLE
Update Rust Style Guide link

### DIFF
--- a/src/en/02_devenv.md
+++ b/src/en/02_devenv.md
@@ -196,7 +196,7 @@ single_line_if_else_max_width = 40
 ```
 
 For more information about the guidelines that `rustfmt` will check, have a look
-at the [Rust Style Guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md).
+at the [Rust Style Guide](https://github.com/rust-lang/rust/tree/master/src/doc/style-guide/src).
 
 > ### Rule {{#check DENV-FORMAT | Use Rust formatter (rustfmt)}}
 > The tool `rustfmt` can be used to ensure that the codebase respects style

--- a/src/fr/02_devenv.md
+++ b/src/fr/02_devenv.md
@@ -224,7 +224,7 @@ single_line_if_else_max_width = 40
 ```
 
 Pour plus d'informations à propos des règles de convention de style que
-`rustfmt` propose, voir le [*Rust Style Guide*](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md).
+`rustfmt` propose, voir le [*Rust Style Guide*](https://github.com/rust-lang/rust/tree/master/src/doc/style-guide/src).
 
 > ### Règle {{#check DENV-FORMAT | Utilisation d'un outil de formatage (rustfmt)}}
 >


### PR DESCRIPTION
Hi !

Just a quick fix to update the Rust Style Guide link in the "rustfmt" section for both french and english languages.

Regards,
Xen0r.