### PR TITLE
[rule] Removed requirement to update dependencies

### DIFF
--- a/src/en/libraries.md
+++ b/src/en/libraries.md
@@ -61,23 +61,30 @@ Each third-party dependency should be properly validated, and each validation sh
 
 ## Dependency validation tools
 
-### Cargo-outdated
+### Dependency Updates
 
-[Cargo-outdated] tool allows one to easily manage dependencies' versions.
+Updating third-party libraries is essential to ensure that any potential vulnerabilities are properly addressed.
 
-For a given crate, it lists current dependencies' versions (using its
-`Cargo.toml`), and checks the latest compatible version and also the latest general
-version.
+The dependency resolution mechanism relies on the `Cargo.toml` and `Cargo.lock` files.
 
-<div class="reco" id="LIBS-OUTDATED" type="Rule" title="Check for outdated dependencies versions (cargo-outdated)">
+* The `Cargo.toml` file lists the constraints defined by the developers.
+* The `Cargo.lock` file records the resolution of these constraints by Cargo *at a given point in time*.
 
-The `cargo-outdated` tool must be used to check dependencies' status. Then,
-each outdated dependency must be updated or the choice of the version must be
-justified.
+Therefore, updating dependencies occurs at several levels.
 
-</div>
+* The `Cargo.toml` file can be updated to use a new version of a dependency.
+  On the next build, the `Cargo.lock` file will be updated accordingly.
+* For a given `Cargo.toml` file, dependency resolution by Cargo can change between two points in time.
+  Indeed, new versions of dependencies may have been published in the meantime.
+  Thus, to update dependencies while keeping the constraints from `Cargo.toml`, you can update the `Cargo.lock` file using the `cargo update` command,
+  which is equivalent to deleting the `Cargo.lock` file and rebuilding it, or applying `cargo generate-lockfile`. <!-- verified by the test, but is this always the case? -->
 
-[cargo-outdated]: https://github.com/kbknapp/cargo-outdated
+  The `cargo update` command also allows you to update only a subset of dependencies. For example:
+
+  ```
+  cargo update serde clap
+  ```
+
 
 ### Cargo-audit
 

--- a/src/fr/libraries.md
+++ b/src/fr/libraries.md
@@ -61,25 +61,32 @@ Chaque dépendance tierce devrait être dûment validée, et chaque validation d
 
 ## Outils de vérification des dépendances
 
-### Cargo-outdated
+### Mise à jour des dépendances
 
-L'outil [Cargo-outdated] permet de faciliter la gestion des versions des
-dépendances.
+La mise à jour des bibliothèques tierces est primordiale pour assurer la bonne 
+correction d'éventuelles vulnérabilités.
 
-Pour une *crate* donnée, l'outil liste les versions utilisées des dépendances
-(dépendances listées dans le fichier `Cargo.toml`), et vérifie s'il s'agit de la
-dernière version compatible disponible ainsi que la dernière version en général.
+Le mécanisme de résolution des dépendances s'appuie sur les fichiers `Cargo.toml` et
+`Cargo.lock`.
 
-<div class="reco" id="LIBS-OUTDATED" type="Règle" title="Vérification des dépendances obsolètes (cargo-outdated)">
+* Le fichier `Cargo.toml` liste les contraintes imposées par les développeur
+* Le fichier `Cargo.lock` trace la résolution de ces contraintes par Cargo *à un moment donnée*.
 
-L'outil `cargo-outdated` doit être utilisé pour vérifier le statut des
-dépendances. Ensuite, chaque dépendance importée en version obsolète doit
-être mise à jour ou bien, le cas échéant, le choix de la version doit être
-justifié.
+Aussi, la mise à jour des dépendances intervient à plusieurs niveau.
 
-</div>
+* Le fichier `Cargo.toml` peut être mis à jour pour utiliser une nouvelle version d'une dépendance.
+  À la prochaine compilation, le fichier `Cargo.lock` sera mis à jour en conséquence.
+* Pour un fichier `Cargo.toml` donné, la résolution des dépendances par cargo peut changer entre deux instants.
+  En effet, de nouvelles version de dépendances on pu être publiées dans ce lapse de temps.
+  Aussi, pour mettre à jour les dépendances tout en conservant les contraintes de `Cargo.toml`, on 
+  peut mettre à jour le fichier `Cargo.lock` grâce à la commande `cargo update`,
+  ce qui revient à supprimer le fichier `Cargo.lock` et le reconstruire ou d'appliquer `cargo generate-lockfile`. <!-- vérifié par le test mais est-ce tout le temps le cas ? -->
 
-[cargo-outdated]: https://github.com/kbknapp/cargo-outdated
+  La commande `cargo update` permet aussi de ne mettre à jour qu'une partie des dépendances. Par exemple
+
+  ```
+  cargo update serde clap
+  ```
 
 ### Cargo-audit
 


### PR DESCRIPTION
- This rule has been replaced by simple explanation of Cargo dependencies resolution and means to update dependencies.
- the use of third party tool `cargo-outdated` was withdrawn because its benefit compared to the official tool `cargo update` is not obvious
- Early dependency update VS on-need dependency update is a debated question, that's why rule has been removed

Fixes #102  