### PR TITLE
Safety: Add more context on panics for binaries 

### DIFF
--- a/src/en/errors.md
+++ b/src/en/errors.md
@@ -56,7 +56,7 @@ Common patterns that can cause panics are:
 <div class="warning">
 
 In certain safety‑critical domains, it is mandatory to transition to a safe‑mode state whenever an error occurs that could otherwise lead to undefined behavior.
-In these situations, deliberately triggering a panic (or aborting execution) makes sense because it stops the system before corrupted data or safety or security‑related faults can propagate.
+In these situations, deliberately triggering a panic (or aborting execution) makes sense because it stops the system before corrupted data or safety and security‑related faults can propagate.
 
 For a plane or other vehicles, this “fail‑fast” behavior can be crucial: the primary control unit must halt immediately on a serious fault, then hand over control to a redundant or backup subsystem that can bring the vehicule to a safe stop or continue operation in a reduced‑capability mode. Restarting on a trusted secondary system ensures that the plane remains controllable, protects occupants, and prevents hazardous outcomes that could arise from continuing execution in an unpredictable state.
 

--- a/src/fr/errors.md
+++ b/src/fr/errors.md
@@ -60,9 +60,9 @@ Des motifs courants de code qui provoquent des `panic` sont :
 <div class="warning">
 
 Dans certains domaines critiques pour la sécurité, il est obligatoire de passer en mode sans échec dès qu'une erreur susceptible d'entraîner un comportement indéfini se produit.
-Dans ces situations, il est judicieux de déclencher délibérément un panic (ou d'interrompre l'exécution) puisque cela permet d'arrêter le système avant que des données corrompues, des invariants violés ou des défaillances liées à la sureté ou la sécurité ne se propagent.
+Dans ces situations, il est judicieux de déclencher délibérément un panic (ou d'interrompre l'exécution) puisque cela permet d'arrêter le système avant que des données ne soient corrompues, ou des défaillances liées à la sureté ou la sécurité ne se propagent.
 
-Pour un avion ou d'autres types de véhicule, ce comportement « fail-fast » peut être crucial : l'unité de contrôle principale doit s'arrêter immédiatement en cas de défaillance grave, puis transférer le contrôle à un sous-système redondant ou de secours capable d'arrêter le véhicule en toute sécurité ou de poursuivre son fonctionnement en mode réduit. Le redémarrage sur un système secondaire fiable garantit que le véhicule reste contrôlable, protège les occupants et évite les conséquences dangereuses qui pourraient résulter de la poursuite de l'exécution dans un état imprévisible
+Pour un avion ou d'autres types de véhicule, ce comportement « fail-fast » peut être crucial : l'unité de contrôle principale doit s'arrêter immédiatement en cas de défaillance grave, puis transférer le contrôle à un sous-système redondant ou de secours capable d'arrêter le véhicule en toute sécurité ou de poursuivre son fonctionnement en mode réduit. Le redémarrage sur un système secondaire fiable garantit que le véhicule reste contrôlable, protège les occupants et évite les conséquences dangereuses qui pourraient résulter de la poursuite de l'exécution dans un état imprévisible.
 
 </div>
 


### PR DESCRIPTION
Avoiding panics is not as simple as it seems, panicking can actually be safer than handling an error and can even be required by safety standards:
- ISO 26262
- IEC 61508
- DO‑178C
- ED204
- ASIL, SIL, EN 9100/ARP 4754
- Etc.

This PR adds more context on panics for binaries when safety is required (E.g: planes, cars, medical devices...).