### PR TITLE
Unsafe: add performance considerations

### DIFF
--- a/src/en/unsafe/generalities.md
+++ b/src/en/unsafe/generalities.md
@@ -87,6 +87,8 @@ structure or module) shall be provided.
 
 * A function can be marked unsafe globally (by prefixing its declaration with the `unsafe` keyword) when it may exhibit unsafe behaviors based on its arguments, that are unavoidable. For instance, this happens when a function tries to dereference a pointer passed as an argument.
 
+* When hitting a performance wall on a small portion of code (E.G: Zero-copy buffer modified in-place, Allocation overhead, etc.).
+
 With the exception of these cases, `#![forbid(unsafe_code)]` must appear in the crate root (typically `main.rs` or `lib.rs`) to generate compilation errors if `unsafe` is used in the code base.
 
 </div>

--- a/src/fr/unsafe/generalities.md
+++ b/src/fr/unsafe/generalities.md
@@ -107,6 +107,8 @@ peuvent être utilisés, à la condition que leur usage soit justifié :
   comportements non sûrs en fonction de ses arguments. Par exemple, cela
   arrive lorsqu'une fonction doit déréférencer un pointeur passé en argument.
 
+* Lorsque les performances sont impactées sur une petite partie de code (Buffer zero-copy modifié directement en mémoire, gestion des allocations, etc.).
+
 À l'exception de l'un ou plusieurs de ces cas `#![forbid(unsafe_code)]` doit
 apparaître dans à la racine de la *crate* (typiquement `main.rs` ou `lib.rs`)
 afin de générer des erreurs de compilation dans le cas ou le mot-clé `unsafe`


### PR DESCRIPTION
### Discussion / Proposal

Some software developments requiring high performance totally justify the occasional use of unsafe code.

**E.G: Crossbeam requires the use of unsafe for:**
 - Atomic pointer manipulation
 - Memory ordering guarantees
 - Lock-free strictures

**Crossbeam** is considered as _safe_ and is used by tons of crates including tokio, rayon etc.

**E.G: Hign performance text processing requires unsafe for :** 
 - Direct SIMD instruction access
 - Custom string validation (UTF-8)
 - Buffer modification for zero-copy 

...

In many cases, using unsafe code will required an **_isolation pattern_** as : 
- A safe UAPI
- A validation layer (inputs checks)
- Unsafe code for performance
  - Strict _unsafe_ justifications & documentation
  - Fully acknowledged team comprehension
  - Fuzzing
  - Unit & integration tests
  - Loom testing (for concurrent code)
  - Formal proofs